### PR TITLE
Get db_path from environment variable STORAGE_INTERFACE_DB_PATH

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use rocksdb::DB;
 use std::convert::TryInto;
 use std::os::raw::c_char;
 use std::slice;
+use std::env;
 
 #[no_mangle]
 pub extern "C" fn store_byte_array(
@@ -19,7 +20,10 @@ pub extern "C" fn store_byte_array(
         assert!(!value_array_pointer.is_null());
         slice::from_raw_parts(value_array_pointer as *const _, value_size as usize)
     };
-    let db_path = "/media/nvme/ssvm_database";
+    let db_path = match env::var("STORAGE_INTERFACE_DB_PATH") {
+        Ok(val) => val,
+        Err(e) => "/media/nvme/ssvm_database",
+    }
     let db = DB::open_default(db_path).unwrap();
     db.put(key, value).unwrap();
 }
@@ -33,7 +37,10 @@ pub extern "C" fn get_byte_array_pointer(
         assert!(!key_array_pointer.is_null());
         slice::from_raw_parts(key_array_pointer as *const _, key_size as usize)
     };
-    let db_path = "/media/nvme/ssvm_database";
+    let db_path = match env::var("STORAGE_INTERFACE_DB_PATH") {
+        Ok(val) => val,
+        Err(e) => "/media/nvme/ssvm_database",
+    }
     let db = DB::open_default(db_path).unwrap();
     let loaded_data = db.get(&key).unwrap().unwrap();
     let data = loaded_data.as_ptr() as *mut _;
@@ -50,7 +57,10 @@ pub extern "C" fn get_byte_array_length(
         assert!(!key_array_pointer.is_null());
         slice::from_raw_parts(key_array_pointer as *const _, key_size as usize)
     };
-    let db_path = "/media/nvme/ssvm_database";
+    let db_path = match env::var("STORAGE_INTERFACE_DB_PATH") {
+        Ok(val) => val,
+        Err(e) => "/media/nvme/ssvm_database",
+    }
     let db = DB::open_default(db_path).unwrap();
     let loaded_data = db.get(&key).unwrap();
     let size: size_t = loaded_data.unwrap().len().try_into().unwrap();


### PR DESCRIPTION
I found that the db_path is hard coding in the source code.
It will be great if we can let developers to use environment variable to change `db_path`